### PR TITLE
Remove the custom getter in the argument list for NewAttribute

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -9,7 +9,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2017.09.10", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2017.11.05", ## Sebas' version
+  "2018.01.25", ## Sebas' version
 ## this line prevents merge conflicts
 ] ),
 

--- a/ToolsForHomalg/gap/ToolsForHomalg.gi
+++ b/ToolsForHomalg/gap/ToolsForHomalg.gi
@@ -1355,13 +1355,15 @@ end );
 ##
 InstallGlobalFunction( DeclareAttributeWithCustomGetter,
   function ( arg )
-    local  attr, name, custom_getter, nname, gvar, pos, filter;
+    local  attr, name, custom_getter, nname, gvar, pos, filter, new_attribute_args;
     name := arg[1];
     custom_getter := arg[3];
+    new_attribute_args := ShallowCopy( arg );
+    Remove( new_attribute_args, 3 );
     if IsBoundGlobal( name )  then
         Error( "expected a name not bound" );
     else
-        attr := CallFuncList( NewAttribute, arg );
+        attr := CallFuncList( NewAttribute, new_attribute_args );
         BindGlobal( name, custom_getter );
         nname := "Set";
         Append( nname, name );


### PR DESCRIPTION
since the new master version of GAP checks all arguments passed to NewAttribute.

Please review and merge this as soon as possible, as this prevents homalg from being loaded in gap-systems travis tests.